### PR TITLE
(smallfix) Fix space in statement that throws `UnsupportedOperationException`

### DIFF
--- a/bivrost-abi-parser/src/main/kotlin/pm/gnosis/AbiParser.kt
+++ b/bivrost-abi-parser/src/main/kotlin/pm/gnosis/AbiParser.kt
@@ -205,7 +205,7 @@ object AbiParser {
             .returns(String::class)
             .addModifiers(KModifier.OVERRIDE)
             .addStatement(
-                "throw·UnsupportedOperationException(\"Structs are  not supported via encodePacked\")"
+                "throw·UnsupportedOperationException(\"Structs are not supported via encodePacked\")"
             )
             .build()
 


### PR DESCRIPTION
Due to typo the generated wrapper for contract cannot compile
That's what I'm getting when building with bivrost plugin `0.8.1`
![image](https://github.com/5afe/bivrost-kotlin/assets/22574399/107d7c47-12fe-4eba-aa72-5df150ffadbe)

The same code with fixed line works perfect
Hovewer this issue prevents from using `bivrost` gradle plugin as build fails

Changes proposed in this pull request:
- Remove spacing symbol from statement throwing `UnsupportedOperationException`